### PR TITLE
Make auth more like mosrs cache password

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         version  = '0.4.0',
         packages = find_packages(),
         install_requires = [
-            'python-ldap',
+            'python-ldap <= 3.3.1',
             'requests',
             ],
         entry_points = {


### PR DESCRIPTION
Closes issue #6 
Tested on OOD. Note: `auth` now assumes that the `rose` command can be found. Make the `mosrs-setup` module depend on the `rose` module.
