### PR TITLE
Deprecate accessdev

### DIFF
--- a/mosrs/auth.py
+++ b/mosrs/auth.py
@@ -27,7 +27,9 @@ from subprocess import Popen, PIPE
 
 import requests
 
-from . import gpg
+from . import gpg, host
+from host import get_host, on_accessdev, on_ood
+from message import info, warning, todo
 
 svn_servers = os.path.join(os.environ['HOME'],'.subversion/servers')
 
@@ -192,6 +194,9 @@ def check_or_update():
         update(user)
 
 def main():
+    if on_accessdev():
+        warning('This version of mosrs-auth is not intended to run on accessdev and may not work correctly.')
+
     parser = argparse.ArgumentParser(description="Cache password to MOSRS for Rose and Subversion")
     parser.add_argument('--force',dest='force',action='store_true',help='force cache refresh of both username and password')
     args = parser.parse_args()

--- a/mosrs/host.py
+++ b/mosrs/host.py
@@ -1,0 +1,44 @@
+"""
+Copyright 2016 ARC Centre of Excellence for Climate Systems Science
+
+author: Scott Wales <scott.wales@unimelb.edu.au>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import socket
+
+def get_host():
+    hostname = socket.gethostname()
+    for name in [
+            "accessdev",
+            "gadi-login",
+            "ood"]:
+        if name in hostname:
+            return name
+    for name in [
+            "gadi-analysis",
+            "gadi-dm",
+            ]:
+        if name in hostname:
+            return "ARE"
+    return "unsupported"
+
+def on_accessdev():
+    hostname = get_host()
+    return hostname == "accessdev"
+
+def on_ood():
+    hostname = get_host()
+    return hostname == "ood"
+

--- a/mosrs/message.py
+++ b/mosrs/message.py
@@ -1,0 +1,39 @@
+"""
+Copyright 2016 ARC Centre of Excellence for Climate Systems Science
+
+author: Scott Wales <scott.wales@unimelb.edu.au>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import print_function
+
+def colour(text, colour):
+    if colour == 'red':
+        code = '\033[31;1m'
+    elif colour == 'green':
+        code = '\033[32m'
+    elif colour == 'blue':
+        code = '\033[93m'
+    else:
+        raise Exception
+    reset = '\033[m'
+    return code + text + reset
+
+def info(text):
+    print("%s: %s"%(colour('INFO','blue'),text))
+def warning(text):
+    print("%s: %s"%(colour('WARN','red'),text))
+def todo(text):
+    print("%s: %s"%(colour('TODO','green'),text))
+    

--- a/mosrs/setup.py
+++ b/mosrs/setup.py
@@ -26,26 +26,9 @@ import ldap
 import getpass
 import socket
 
-from . import auth, gpg
-
-def colour(text, colour):
-    if colour == 'red':
-        code = '\033[31;1m'
-    elif colour == 'green':
-        code = '\033[32m'
-    elif colour == 'blue':
-        code = '\033[93m'
-    else:
-        raise Exception
-    reset = '\033[m'
-    return code + text + reset
-
-def info(text):
-    print("%s: %s"%(colour('INFO','blue'),text))
-def warning(text):
-    print("%s: %s"%(colour('WARN','red'),text))
-def todo(text):
-    print("%s: %s"%(colour('TODO','green'),text))
+from . import gpg, host, message
+from host import get_host, on_accessdev, on_ood
+from message import info, warning, todo
 
 class SetupError(Exception):
     """
@@ -87,30 +70,6 @@ def prompt_or_default(prompt, default):
     if response == '':
         response = default
     return response
-
-def get_host():
-    hostname = socket.gethostname()
-    for name in [
-            "accessdev",
-            "gadi-login",
-            "ood"]:
-        if name in hostname:
-            return name
-    for name in [
-            "gadi-analysis",
-            "gadi-dm",
-            ]:
-        if name in hostname:
-            return "ARE"
-    return "unsupported"
-
-def on_accessdev():
-    hostname = get_host()
-    return hostname == "accessdev"
-
-def on_ood():
-    hostname = get_host()
-    return hostname == "ood"
 
 def gpg_startup():
     agent = dedent("""
@@ -241,6 +200,7 @@ def accesssvn_setup():
 def main():
     print('\n')
     if on_accessdev():
+        warning('This version of mosrs-setup is not intended to run on accessdev and may not work correctly.')
         print('Welcome to Accessdev, the user interface and control server for the ACCESS model at NCI')
     if on_ood():
         print('Welcome to OOD, the NCI Open OnDemand service')

--- a/mosrs/setup.py
+++ b/mosrs/setup.py
@@ -26,7 +26,7 @@ import ldap
 import getpass
 import socket
 
-from . import gpg, host, message
+from . import auth, gpg, host, message
 from host import get_host, on_accessdev, on_ood
 from message import info, warning, todo
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup, find_packages
 
 setup(
         name     = 'mosrs',
-        version  = '0.4.3',
+        version  = '0.4.4',
         packages = find_packages(),
         install_requires = [
             'python-ldap <= 3.3.1',


### PR DESCRIPTION
Closes issue #17

Note that this version of `mosrs-setup` does not actually work on `accessdev` due to differences in `gpg-agent`.
