### PR TITLE
Consistently use argparse, multiline output strings and dedent

### DIFF
--- a/mosrs/auth.py
+++ b/mosrs/auth.py
@@ -24,6 +24,7 @@ import ConfigParser
 from ConfigParser import SafeConfigParser
 from hashlib import md5
 from subprocess import Popen, PIPE
+from textwrap import dedent
 
 from . import gpg, host
 from host import on_accessdev
@@ -285,8 +286,12 @@ def main():
         else:
             check_or_update()
     except AuthError:
-        todo('Please check your credentials.'
-           + 'If you have recently reset your password it may take a bit of time for the server to recognise the new password.')
+        todo(dedent(
+            """
+            Please check your credentials.
+            If you have recently reset your password it may take a bit of time for the server to recognise the new password.
+            """
+        ))
 
 if __name__ == '__main__':
     main()

--- a/mosrs/setup.py
+++ b/mosrs/setup.py
@@ -18,6 +18,7 @@ limitations under the License.
 """
 
 from __future__ import print_function
+import argparse
 from subprocess import Popen, PIPE
 from textwrap import dedent
 from os import environ, rename, path
@@ -158,6 +159,9 @@ def main():
     if on_accessdev():
         warning('This version of mosrs-setup is not intended to run on accessdev.')
         return
+
+    parser = argparse.ArgumentParser(description="Set up MOSRS authentication for Rose and Subversion by storing credentials")
+    args = parser.parse_args()
 
     print('This script will set up your account to use Rose and the MOSRS Subversion repositories\n')
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup, find_packages
 
 setup(
         name     = 'mosrs',
-        version  = '0.6.1',
+        version  = '0.6.2',
         description = 'Cache credentials for NCI users of MOSRS',
         license = 'Apache License, Version 2.0',
         packages = find_packages(),


### PR DESCRIPTION
Closes issue #57. Closes issue #58.
