### PR TITLE
Address "rsync backup sometimes fails"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ optional arguments:
 - It performs the actions listed under `mosrs-auth` below.
 - It also edits your `$HOME/.bashrc` file, if necessary. The updated `.bashrc` file starts up `gpg-agent` automatically for interactive login shells.
   - If `$HOME/.bashrc` is changed, it is first backed up to the directory `$HOME/.mosrs-setup/backup.$TODAY.$PID` where `$TODAY` is today's date in ISO format and `$PID` is the current process ID.
+    - The backup is best-effort. If the backup fails, a warning is given and the changes are still made.
   - If you do not want your `$HOME/.bashrc` file changed, do not run `mosrs-setup`. Just run `mosrs-auth` instead.
 
 `mosrs-auth`:
@@ -53,3 +54,4 @@ optional arguments:
   - Creates the directory `$HOME/.metomi` and the file `$HOME/.metomi/rose.conf` and adds your MOSRS username there, if your username is not already stored there.
   - Caches your MOSRS password for at most 12 hours, and checks it using both `svn` and `rosie`.
   - If any files in any of the `$HOME/.gnupg`, `$HOME/.metomi` or `$HOME/.ssh` directories are changed, the whole directory is first backed up to the directory `$HOME/.mosrs-setup/backup.$TODAY.$PID` where `$TODAY` is today's date in ISO format and `$PID` is the current process ID.
+    - The backup is best-effort. If the backup fails, a warning is given and the changes are still made.

--- a/mosrs/backup.py
+++ b/mosrs/backup.py
@@ -22,7 +22,7 @@ from os import environ, getpid, makedirs, path
 from subprocess import Popen, PIPE
 
 from mosrs.exception import BackupError
-from mosrs.message import debug
+from mosrs.message import debug, warning
 
 def get_backup_path():
     """
@@ -71,9 +71,11 @@ def backup(path_name):
     if not path.exists(full_backup_path):
         # Backup the file or directory
         process = Popen(
-            ['rsync', '-a', full_path, backup_path],
+            ['rsync', '-a', '--no-o', '--no-g', full_path, backup_path],
             stdout=PIPE,
             stderr=PIPE)
         _stdout, stderr = process.communicate()
         if process.returncode != 0:
-            raise BackupError('Backup via rsync failed: {}'.format(stderr))
+            warning('Backup via rsync failed: {}'.format(stderr))
+            return False
+    return True

--- a/mosrs/backup.py
+++ b/mosrs/backup.py
@@ -19,6 +19,7 @@ limitations under the License.
 
 from datetime import date
 from os import environ, getpid, makedirs, path
+from shutil import rmtree
 from subprocess import Popen, PIPE
 
 from mosrs.exception import BackupError
@@ -76,6 +77,8 @@ def backup(path_name):
             stderr=PIPE)
         _stdout, stderr = process.communicate()
         if process.returncode != 0:
+            # Backup failed. Try to clean up
+            rmtree(full_backup_path, ignore_errors=True)
             warning('Backup via rsync failed: {}'.format(stderr))
             return False
     return True

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mosrs',
-    version='0.9.0',
+    version='0.9.1',
     description='Cache credentials for NCI users of MOSRS',
     license='Apache License, Version 2.0',
     packages=find_packages(),


### PR DESCRIPTION
Closes issue #91 

In `mosrs/backup.py`
- Changed backup command to `rsync -a --no-o --no-g`
- On failure, remove the incomplete backup and print a warning message
- The `mosrs.backup.backup` function now returns `True` on success and `False` on recovered failure.
  - This return value is not yet used.