### PR TITLE
Improve backups

### DIFF
--- a/mosrs/backup.py
+++ b/mosrs/backup.py
@@ -71,6 +71,7 @@ def backup(path_name):
     full_backup_path = path.join(backup_path, path_name)
     if not path.exists(full_backup_path):
         # Backup the file or directory
+        debug('Backing up {}.'.format(path_name))
         process = Popen(
             ['rsync', '-a', '--no-o', '--no-g', full_path, backup_path],
             stdout=PIPE,

--- a/mosrs/gpg.py
+++ b/mosrs/gpg.py
@@ -110,6 +110,22 @@ def set_environ():
         stdout_line = stdout.splitlines()[0]
         environ['GPG_AGENT_INFO'] = stdout_line + ':0:1'
 
+GNUPG_BASENAME = '.gnupg'
+GNUPG_DIR = path.join(environ['HOME'], GNUPG_BASENAME)
+
+def backup_gnupg():
+    """
+    Backup the ~/.gnupg directory
+    """
+    backup(GNUPG_BASENAME)
+
+def mkdir_gnupg():
+    """
+    Create the ~/.gnupg directory if it does not exist
+    """
+    if not path.exists(GNUPG_DIR):
+        mkdir(GNUPG_DIR, 0o700)
+
 def check_gpg_agent_conf():
     """
     Check the user's GPG agent configuration and append any missing lines
@@ -118,17 +134,13 @@ def check_gpg_agent_conf():
     gpg_agent_conf_allow_preset_passphrase = 'allow-preset-passphrase'
     gpg_agent_conf_max_cache_ttl = 'max-cache-ttl 43200'
 
-    home = environ['HOME']
-    gnupg_dir_name = '.gnupg'
-    gnupg_dir_path = path.join(home, gnupg_dir_name)
-    if not path.exists(gnupg_dir_path):
-        mkdir(gnupg_dir_path, 0o700)
-        conf_updated = True
-        debug('Created {}'.format(gnupg_dir_path))
+    # Create the ~/.gnupg directory if it does not exist
+    mkdir_gnupg()
     gpg_agent_conf_name = 'gpg-agent.conf'
-    gpg_agent_conf_path = path.join(gnupg_dir_path, gpg_agent_conf_name)
+    gpg_agent_conf_path = path.join(GNUPG_DIR, gpg_agent_conf_name)
     if not path.exists(gpg_agent_conf_path):
-        backup(gnupg_dir_name)
+        # Backup the ~/.gnupg directory
+        backup_gnupg()
         with open(gpg_agent_conf_path, 'w') as gpg_agent_conf_file:
             gpg_agent_conf_file.write(gpg_agent_conf_allow_preset_passphrase + '\n')
             gpg_agent_conf_file.write(gpg_agent_conf_max_cache_ttl + '\n')
@@ -142,7 +154,8 @@ def check_gpg_agent_conf():
             stdout=PIPE)
         grep_command.communicate()
         if grep_command.returncode != 0:
-            backup(gnupg_dir_name)
+            # Backup the ~/.gnupg directory
+            backup_gnupg()
             with open(gpg_agent_conf_path, 'a') as gpg_agent_conf_file:
                 gpg_agent_conf_file.write(gpg_agent_conf_allow_preset_passphrase + '\n')
             conf_updated = True
@@ -153,7 +166,8 @@ def check_gpg_agent_conf():
             stdout=PIPE)
         grep_command.communicate()
         if grep_command.returncode != 0:
-            backup(gnupg_dir_name)
+            # Backup the ~/.gnupg directory
+            backup_gnupg()
             with open(gpg_agent_conf_path, 'a') as gpg_agent_conf_file:
                 gpg_agent_conf_file.write(gpg_agent_conf_max_cache_ttl + '\n')
             conf_updated = True

--- a/mosrs/rose.py
+++ b/mosrs/rose.py
@@ -99,14 +99,26 @@ def get_rose_username():
         debug(unable_message)
         return None
 
-METOMI_DIR = path.join(environ['HOME'], '.metomi')
+METOMI_BASENAME = '.metomi'
+METOMI_DIR = path.join(environ['HOME'], METOMI_BASENAME)
 METOMI_ROSE_CONF = path.join(METOMI_DIR, 'rose.conf')
+
+def backup_or_mkdir_metomi():
+    """
+    Backup or create the ~/.metomi directory
+    """
+    if path.exists(METOMI_DIR):
+        backup(METOMI_BASENAME)
+    else:
+        mkdir(METOMI_DIR, 0o700)
 
 def save_rose_username(username):
     """
     Add the Rose username for prefix u to the Rose configuration file
     """
     debug('Saving MOSRS username "{}" to Rose config.'.format(username))
+    # Backup or create the ~/.metomi directory
+    backup_or_mkdir_metomi()
     config = SafeConfigParser()
     config.add_section('rosie-id')
     config.set('rosie-id', PREFIX_USERNAME_KEY, username)
@@ -118,11 +130,6 @@ def save_rose_username(username):
         # Remove spaces from " = " delimiter
         # Rose configuration examples do not use " = "
         config_str = config_file.read().replace(' = ', '=', 1)
-    # Create ~/.metomi directory if it does not exist
-    if not path.exists(METOMI_DIR):
-        mkdir(METOMI_DIR, 0o755)
-    # Backup the ~/.metomi directory
-    backup('.metomi')
     # Append the config string to the Rose configuration
     with open(METOMI_ROSE_CONF, 'a') as rose_conf_file:
         rose_conf_file.write(config_str)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mosrs',
-    version='0.9.7',
+    version='0.9.8',
     description='Cache credentials for NCI users of MOSRS',
     license='Apache License, Version 2.0',
     packages=find_packages(),


### PR DESCRIPTION
Closes issue #105 
The `backup` functions already prevent multiple backup directories and multiple backups from being created. These changes improve the use of the backup functions, and prevent empty directories from being backed up.
